### PR TITLE
Initialize Expo React Native project with TypeScript

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_URL=https://api.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
+node_modules/
+
+# Expo
+.expo/
+dist/
+web-build/
+expo-env.d.ts
+
+# Native
+.kotlin/
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+.DS_Store
+*.pem
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo
+
+# lockfile
+package-lock.json
+
+# assets
+assets/

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,29 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? 'Not set';
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to Baggie!</Text>
+      <Text>API URL: {apiUrl}</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# baggie-app-expo-react-native
-Official repo. of baggie an app for android and ios where users can make Bag List to travel with AI and save all countries they gave been
+# Baggie App
+
+Aplicación móvil creada con [Expo](https://expo.dev/) y React Native usando TypeScript.
+
+## Requisitos
+- Node.js 18+
+- npm 9+
+- Expo CLI (se instala automáticamente con `npm start`)
+
+## Instalación
+```bash
+npm install
+```
+
+## Variables de entorno
+Crea un archivo `.env` en la raíz con las variables necesarias:
+```env
+EXPO_PUBLIC_API_URL=https://api.example.com
+```
+
+## Ejecutar la aplicación
+- Android: `npm run android`
+- iOS: `npm run ios`
+- Web: `npm run web`
+
+## Notas
+La aplicación actualmente sólo contiene una interfaz básica de bienvenida y muestra la URL de la API configurada en el archivo `.env`.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,20 @@
+{
+  "expo": {
+    "name": "baggie-app-expo-react-native",
+    "slug": "baggie-app-expo-react-native",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "light",
+    "newArchEnabled": true,
+    "splash": {
+      "backgroundColor": "#ffffff"
+    },
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "edgeToEdgeEnabled": true
+    },
+    "web": {}
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "baggie-app-expo-react-native",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~53.0.22",
+    "expo-status-bar": "~2.2.3",
+    "react": "19.0.0",
+    "react-native": "0.79.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@types/react": "~19.0.10",
+    "typescript": "~5.8.3"
+  },
+  "private": true
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Expo project using latest SDK and TypeScript
- show basic welcome UI referencing a public API URL from environment variables
- remove binary assets and lockfile to keep repository lean

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script: "test"* )

------
https://chatgpt.com/codex/tasks/task_e_68b34c0c0b488328bff0eee2802989ca