### PR TITLE
feat: add world map screen for visited countries

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import ListsScreen from './src/screens/ListsScreen';
 import TripDetailsScreen from './src/screens/TripDetailsScreen';
 import CreateDestinationScreen from './src/screens/CreateDestinationScreen';
 import CreateAccommodationScreen from './src/screens/CreateAccommodationScreen';
+import VisitedMapScreen from './src/screens/VisitedMapScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -29,6 +30,11 @@ export default function App() {
           name="CreateAccommodation"
           component={CreateAccommodationScreen}
           options={{ title: 'Accommodation' }}
+        />
+        <Stack.Screen
+          name="VisitedMap"
+          component={VisitedMapScreen}
+          options={{ title: 'World Map' }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "react": "19.0.0",
     "react-native": "0.79.6",
     "react-native-safe-area-context": "^5.6.1",
-    "react-native-screens": "^4.15.4"
+    "react-native-screens": "^4.15.4",
+    "@svg-maps/world": "^1.0.1",
+    "react-native-svg": "^15.12.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -17,6 +17,9 @@ export default function HomeScreen({ navigation }: Props) {
       <Pressable style={styles.button} onPress={() => navigation.navigate('CreateDestination')}>
         <Text style={styles.buttonText}>Create Trip</Text>
       </Pressable>
+      <Pressable style={styles.button} onPress={() => navigation.navigate('VisitedMap')}>
+        <Text style={styles.buttonText}>World Map</Text>
+      </Pressable>
       <Text style={styles.env}>API URL: {apiUrl}</Text>
     </View>
   );

--- a/src/screens/VisitedMapScreen.tsx
+++ b/src/screens/VisitedMapScreen.tsx
@@ -1,0 +1,52 @@
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+import World from '@svg-maps/world';
+
+const world: any = World;
+
+// TODO: Replace with real user data
+const visited = ['US', 'CA', 'MX'];
+
+const { width } = Dimensions.get('window');
+const height = width / 2;
+
+export default function VisitedMapScreen() {
+  const visitedSet = new Set(visited);
+  const totalCountries = world.paths.length;
+  const visitedCount = visitedSet.size;
+  const percentage = ((visitedCount / totalCountries) * 100).toFixed(1);
+
+  return (
+    <View style={styles.container}>
+      <Svg width={width} height={height} viewBox={world.viewBox}>
+        {world.paths.map((country: any) => (
+          <Path
+            key={country.id}
+            d={country.d}
+            fill={visitedSet.has(country.id) ? '#FFB300' : '#ECEFF1'}
+            stroke="#FFFFFF"
+            strokeWidth={0.5}
+          />
+        ))}
+      </Svg>
+      <Text style={styles.info}>
+        {visitedCount} / {totalCountries} countries visited ({percentage}%)
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: '#fff',
+  },
+  info: {
+    marginTop: 16,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@ export type RootStackParamList = {
   TripDetails: { name: string };
   CreateDestination: undefined;
   CreateAccommodation: undefined;
+  VisitedMap: undefined;
 };


### PR DESCRIPTION
## Summary
- display visited countries on a world map with overall progress
- add navigation from Home screen to new world map view
- include dependencies for SVG map rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b35d840fc08328b3a41bc298137a25